### PR TITLE
Fix :about link for John Graham-Cumming

### DIFF
--- a/pwd.lisp
+++ b/pwd.lisp
@@ -17,7 +17,7 @@
  (:name "John Graham-Cumming"
   :site "https://jgc.org/"
   :feed "https://blog.jgc.org/feeds/posts/default"
-  :about "https://www.seangoedecke.com/about"
+  :about "https://en.wikipedia.org/wiki/John_Graham-Cumming"
   :blog "https://blog.jgc.org/"
   :hnuid "jgc"
   :bio "Original writer of POPFile.  Member of the board of directors at Cloudflare.")


### PR DESCRIPTION
I assume that having Sean Goedecke's about link here was a copy-paste error.