### PR TITLE
fix: ensure link to outcoldman/hackernews-personal-blogs works

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ FAQ
     Contributions that add entries to this project, whether sourced
     from that list or elsewhere, are very welcome.
 
-[outcoldman]: outcoldman/hackernews-personal-blogs
+[outcoldman]: https://github.com/outcoldman/hackernews-personal-blogs
 
 
 Licence


### PR DESCRIPTION
Clicking the link in the README.md will redirect to `https://github.com/hnpwd/hnpwd.github.io/blob/main/outcoldman/hackernews-personal-blogs` rather than the correct URL