### PR TITLE
Add Barada's personal website (mercurialsolo)

### DIFF
--- a/pwd.lisp
+++ b/pwd.lisp
@@ -49,6 +49,13 @@
   :hnuid "arulpugazh"
   :bio "Canadian ML engineer and founder of TensorHub Solutions Inc.")
 
+ (:name "Barada"
+  :site "https://mercurialsolo.github.io/"
+  :blog "https://mercurialsolo.github.io/posts/"
+  :feed "https://mercurialsolo.github.io/index.xml"
+  :hnuid "mercurialsolo"
+  :bio "Writes about AI product development, model-adjacent systems and technology.")
+
  (:name "Beast Hacker"
   :site "https://beasthacker.com/"
   :about "https://beasthacker.com/about.html"


### PR DESCRIPTION
## Website Details

- **Name**: Barada
- **Site**: https://mercurialsolo.github.io/
- **Blog**: https://mercurialsolo.github.io/posts/
- **RSS Feed**: https://mercurialsolo.github.io/index.xml
- **HN username**: mercurialsolo
- **Bio**: Writes about AI product development, model-adjacent systems, and technology.

## Content

The site features articles on:
- AI product development and architecture
- Model-adjacent systems (products built around LLMs)
- Technology strategy and startup insights

Built with Hugo + PaperMod theme, hosted on GitHub Pages.