### PR TITLE
Add Matthias Klose (kls0e)

### DIFF
--- a/pwd.lisp
+++ b/pwd.lisp
@@ -676,6 +676,12 @@
   :hnuid "ciferkey"
   :bio "Writes about projects events and ideas, sharing lessons learnt with others.")
 
+ (:name "Matthias Klose"
+  :site "https://tilde.town/~kls0e/"
+  :feed "https://tilde.town/~kls0e/index.xml"
+  :hnuid "kls0e"
+  :bio "Writes about digital audio, OpenWrt, freifunk and analog photography.")
+
  (:name "Michael Salim"
   :site "https://michaelsalim.co.uk/"
   :blog "https://michaelsalim.co.uk/blog/"


### PR DESCRIPTION
Add my personal website https://tilde.town/~kls0e/ to the directory.

- Name: Matthias Klose
- HN: kls0e
- Bio: Writes about digital audio, OpenWrt, freifunk and analog photography.