### PR TITLE
Add Oz Gultekin (ozgur.ca)

### DIFF
--- a/pwd.lisp
+++ b/pwd.lisp
@@ -800,6 +800,14 @@
   :hnuid "obahareth"
   :bio "CTO.  Writes about engineering, leadership and personal experiences.")
 
+ (:name "Oz Gultekin"
+  :site "https://ozgur.ca/"
+  :blog "https://ozgur.ca/notes"
+  :feed "https://ozgur.ca/rss.xml"
+  :about "https://ozgur.ca/about"
+  :now "https://ozgur.ca/now"
+  :bio "Product Experience Designer in Montreal.  Keeps a signal space for a noisy mind.")
+
  (:name "Patrick Hough"
   :site "https://huffstler.github.io/"
   :blog "https://huffstler.github.io/blog/"


### PR DESCRIPTION
Adds my personal site to the directory.  Bio is third-person, under 80 chars, no ampersands, no Oxford comma, double-spaced sentences.